### PR TITLE
Fix: v-model is not 2-way binding in Toggle component

### DIFF
--- a/components/Toggle/Toggle.vue
+++ b/components/Toggle/Toggle.vue
@@ -16,6 +16,10 @@
 
 <script>
 export default {
+  model: {
+    prop: 'state',
+    event: 'input'
+  },
   props: {
     state: {
       type: Boolean,


### PR DESCRIPTION
Currently, the following lines will result in a `Toggle` component that is checked, but `state` and `realState` are actually both `false`.

```
<Toggle v-model="someTruthyVal" />

...

  data () {
    return {
      someTruthyVal: true,
    }
  },
```

As a result, clicking the Toggle will invert `realState` from `false` to `true`, therefore keeping the Toggle checked.

I can see that there are actually a `value` and a `state` in `Toggle` component, which seems to duplicate the same functionality.

If you intended to keep `state` instead of the default `value` property, you can simply [customize the prop](https://vuejs.org/v2/api/#model) as `state`. This makes `state` two-way binding. If this looks good, then `value` can be totally removed from the component.